### PR TITLE
Update model.py

### DIFF
--- a/model.py
+++ b/model.py
@@ -20,7 +20,7 @@ class Generator(nn.Module):
         self.block6 = ResidualBlock(64)
         self.block7 = nn.Sequential(
             nn.Conv2d(64, 64, kernel_size=3, padding=1),
-            nn.PReLU()
+            nn.BatchNorm2d(64)
         )
         block8 = [UpsampleBLock(64, 2) for _ in range(upsample_block_num)]
         block8.append(nn.Conv2d(64, 3, kernel_size=9, padding=4))


### PR DESCRIPTION
According to the SRGAN paper, in the generator, after the last residual block, right before the element wise sum, there is a BatchNorm layer and not a PRelu.

![Screenshot 2019-05-05 at 4 20 58 PM](https://user-images.githubusercontent.com/24846546/57192846-ad7a8500-6f52-11e9-8908-885275e5e87b.png)


